### PR TITLE
Fix page browser rendering issue when using "2-reader-header-centered" and "2-reader-header-cornered"

### DIFF
--- a/2-reader-header-centered.lua
+++ b/2-reader-header-centered.lua
@@ -49,6 +49,7 @@ local screen_width = Screen:getWidth()
 ReaderView.paintTo = function(self, bb, x, y)
     _ReaderView_paintTo_orig(self, bb, x, y)
     if self.render_mode ~= nil then return end -- Show only for epub-likes and never on pdf-likes
+    if bb ~= Screen.bb then return end -- Only draw on the real screen; skip off-screen renders (page browser / book map thumbnails), otherwise their thumbnails never load
     -- don't change anything above this line
 
 

--- a/2-reader-header-cornered.lua
+++ b/2-reader-header-cornered.lua
@@ -49,6 +49,7 @@ local screen_width = Screen:getWidth()
 ReaderView.paintTo = function(self, bb, x, y)
     _ReaderView_paintTo_orig(self, bb, x, y)
     if self.render_mode ~= nil then return end -- Show only for epub-likes and never on pdf-likes
+    if bb ~= Screen.bb then return end -- Only draw on the real screen; skip off-screen renders (page browser / book map thumbnails), otherwise their thumbnails never load
     -- don't change anything above this line
 
 


### PR DESCRIPTION
This small modification to your patches ensures that the header file does not run when the page is being rendered for the page browser. This allows pages in the page browser to render once more.